### PR TITLE
Add Settings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In addition to being able to supply NuclearSecrets with the type of a secret,
 you can also pass a Proc or a Lambda. If the proc or lamba returns true when
 passed the value of the secret, then the secret will be allowed.
 
-```
+```ruby
 NuclearSecrets.configure do |config|
   config.required_secrets = {
     my_string_secret: String,
@@ -44,6 +44,22 @@ NuclearSecrets.configure do |config|
   }
 end
 ```
+
+## Settings
+You can add a settings object in the configure as well:
+
+```ruby
+NuclearSecrets.configure do |config|
+  config.required_secrets = {
+    ...
+  }
+  config.settings = {
+    raise_on_extra_secrets: false,
+  }
+end
+```
+
+  * `raise_on_extra_secrets`: raises an error when extra secrets are present(defaults to `false`)
 
 ## Contributing
 Contribution directions go here.

--- a/lib/nuclear_secrets/version.rb
+++ b/lib/nuclear_secrets/version.rb
@@ -1,3 +1,3 @@
 module NuclearSecrets
-  VERSION = "1.0.2".freeze
+  VERSION = "1.0.4".freeze
 end

--- a/test/nuclear_secrets_test.rb
+++ b/test/nuclear_secrets_test.rb
@@ -20,10 +20,32 @@ class NuclearSecrets::Test < ActiveSupport::TestCase
         c.required_secrets = {
           one_fish: String,
         }
+        c.settings = {
+          raise_on_extra_secrets: true,
+        }
       end
       NuclearSecrets.check_secrets(
         {
           one_fish: "Red Fish",
+          two_fish: 2,
+        },
+      )
+    end
+  end
+
+  test "log warning when extra secrets are provided" do
+    assert_nothing_raised do
+      NuclearSecrets.configure do |c|
+        c.required_secrets = {
+          three_fish: String,
+        }
+        c.settings = {
+          raise_on_extra_secrets: false,
+        }
+      end
+      NuclearSecrets.check_secrets(
+        {
+          three_fish: "Red Fish",
           two_fish: 2,
         },
       )


### PR DESCRIPTION
* Add Settings to nuclear secrets
* Adds ability to set if you want extra secrets to raise an error. Defaults to false

## Settings
You can add a settings object in the configure as well:

```ruby
NuclearSecrets.configure do |config|
  config.required_secrets = {
    ...
  }
  config.settings = {
    raise_on_extra_secrets: false,
  }
end
```

  * `raise_on_extra_secrets`: raises an error when extra secrets are present(defaults to `false`)
